### PR TITLE
Fix unclosed client session bug

### DIFF
--- a/jsonrpc_websocket/jsonrpc.py
+++ b/jsonrpc_websocket/jsonrpc.py
@@ -60,6 +60,8 @@ class Server(jsonrpc_base.Server):
             raise TransportError('Connection already open.')
 
         try:
+            if self._session.closed:
+                self._session = aiohttp.ClientSession()
             self._client = await self._session.ws_connect(
                 self._url, **self._connect_kwargs)
         except (ClientError, HttpProcessingError, asyncio.TimeoutError) as exc:
@@ -117,11 +119,7 @@ class Server(jsonrpc_base.Server):
             await self._client.close()
             self._client = None
         if self._internal_session:
-            # If we created a clientsession for this Server, close it here.
-            # And then instantiate a new clientsession in case the
-            # connection should be reopened
             await self._session.close()
-            self._session = aiohttp.ClientSession()
 
     @property
     def connected(self):

--- a/tests.py
+++ b/tests.py
@@ -46,6 +46,10 @@ class JsonTestClient():
     def receive_binary(self, data):
         self.test_server.test_binary(data)
 
+    @property
+    def closed(self):
+        self.test_server is None
+
 
 class JsonTestServer(ClientWebSocketResponse):
     def __init__(self, loop=None):


### PR DESCRIPTION
Hello!
I was using your library (very helpful) and found out that I always get this message in the stdout:

```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x1254bfa30>
```

I am sure, that I call `close()` right. And this message also occurs in your examples.

I've tested my project with changes in this PR and it seems to work fine. I'm not an expert in Python, so maybe I've missed something.