### PR TITLE
fix: add async-timeout dependency to address loading error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     install_requires=[
         'jsonrpc-base>=2.1.0',
         'aiohttp>=3.0.0',
+        'async-timeout>=4.0.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
error:

    File "app.py",
    line 4, in <module>
        from jsonrpc_websocket import Server
      File "(snip)/lib/python3.11/site-packages/jsonrpc_websocket/__init__.py",
    line 1, in <module>
        from .jsonrpc import Server, TransportError  # noqa: F401, F403
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "(snip)/lib/python3.11/site-packages/jsonrpc_websocket/jsonrpc.py",
    line 7, in <module>
        import async_timeout

cause:

Actually async-timeout is using in jsonrpc-websocket, it was not added to dependency explicitly. But aiohttp depends on async-timeout until py310, so loading error was not happened until py310. From py311, aiohttp drop async-timeout dependency, after that jsonrpc-websocket cause loading error. see also https://github.com/aio-libs/aiohttp/pull/7558 .